### PR TITLE
Publish Chris-wireframe with github actions

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -54,3 +54,7 @@ jobs:
           gh workflow run deploy.yml -R "owddm/owddm.github.io"
         env:
           GITHUB_TOKEN: ${{ secrets.DEPLOY_GITHUB_TOKEN }}
+      - run: |
+          gh workflow run astro.yml -R "owddm/chris-wireframe"
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEPLOY_GITHUB_TOKEN }}


### PR DESCRIPTION
Previously to this PR I modified my personal deploy token to allow deployments of the chris-workflow environment. With this PR merged any publication of the public repo should trigger chris' page deployment.

See: Github Actions Secrets that contains the token: https://github.com/owddm/public/settings/environments


<details>
<summary>Screenshots </summary>

Before the changes
<img width="1516" height="762" alt="Screenshot 2025-08-03 at 17 52 23" src="https://github.com/user-attachments/assets/250e051d-8423-447d-9247-78f4088d5afc" />

... Afterwards
<img width="791" height="210" alt="Screenshot 2025-08-03 at 17 52 54" src="https://github.com/user-attachments/assets/6ef3d36c-ae72-4980-bbf4-1e12fccc7f84" />

</details>
